### PR TITLE
Speedup

### DIFF
--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -159,15 +159,17 @@ class ZoomSesh:
   # TODO: Fill out this docstring
   def _min_combo(self, alumni, by=None, arg=None, group_size=6):
     num_unique_total = None
+    this_category = None
     if arg == 'diff':
       if by == 'all':
         raise ValueError(f"Incompatible params: by='all', arg='diff'")
       num_unique_total = len(alumni[by].unique())
       indices = alumni.index
+      this_category = alumni[by].values.astype(str)
     elif arg != 'diff' and by != 'all':
       indices = alumni[alumni[by] == arg].index
+      this_category = alumni[by].values.astype(str)
 
-    this_category = alumni[by].values.astype(str)
     counts_cols = [col for col in alumni.columns[3:] if '_' not in col]
     cnsctv_cols = [col for col in alumni.columns[3:] if '_' in col]
   
@@ -199,6 +201,8 @@ class ZoomSesh:
     combos = combinations(indices, group_size)
     combo_arr = np.array(list(combos), dtype='int8')
 
+    if combo_arr.size == 0:
+      return 1
     # Apply `is_combo_diverse` to each combo, only returning 'diverse' combos
     good_combos = np.apply_along_axis(is_combo_diverse, axis=1, arr=combo_arr)
     combo_arr = combo_arr[np.where(good_combos)]

--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -168,8 +168,9 @@ class ZoomSesh:
       else:
         indices = alumni[alumni[by] == arg].index
 
-    counts_cols = [col for col in alumni.columns[3:] if '_' not in col]
-    cnsctv_cols = [col for col in alumni.columns[3:] if '_' in col]
+    n_attrs = len(self.attributes) 
+    counts_cols = [col for col in alumni.columns[n_attrs:] if '_' not in col]
+    cnsctv_cols = [col for col in alumni.columns[n_attrs:] if '_' in col]
   
     counts_arr = alumni[counts_cols].values
     cnsctv_arr = alumni[cnsctv_cols].values

--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -166,9 +166,12 @@ class ZoomSesh:
       num_unique_total = len(alumni[by].unique())
       indices = alumni.index
       this_category = alumni[by].values.astype(str)
-    elif arg != 'diff' and by != 'all':
-      indices = alumni[alumni[by] == arg].index
-      this_category = alumni[by].values.astype(str)
+    elif arg != 'diff':
+      if by != 'all':
+        indices = alumni[alumni[by] == arg].index
+        this_category = alumni[by].values.astype(str)
+      else:
+        indices = alumni.index
 
     counts_cols = [col for col in alumni.columns[3:] if '_' not in col]
     cnsctv_cols = [col for col in alumni.columns[3:] if '_' in col]

--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -157,7 +157,7 @@ class ZoomSesh:
 
 
   # TODO: Fill out this docstring
-  def min_combo_numpy(self, alumni, by=None, arg=None, group_size=6):
+  def _min_combo(self, alumni, by=None, arg=None, group_size=6):
     num_unique_total = None
     if arg == 'diff':
       if by == 'all':

--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -209,7 +209,7 @@ class ZoomSesh:
 
     min_list = np.where(sums == np.amin(sums))[0]
 
-    return combo_arr[random.choice(min_list)]
+    return list(combo_arr[random.choice(min_list)])
 
     
 

--- a/zoom_sesh.py
+++ b/zoom_sesh.py
@@ -1,3 +1,4 @@
+from numba import jit
 import pandas as pd
 import numpy as np
 import random
@@ -156,56 +157,59 @@ class ZoomSesh:
 
 
   # TODO: Fill out this docstring
-  def _min_combo(self, alumni, by=None, arg=None, group_size=6):
-    '''Creates a random group that minimizes overlap with alumni in previous breakouts.    
-
-    Args:
-      alumni: 
-      by:
-      arg:
-      group_size:
-
-    Returns:
-      combos: a tuple of alumni indices for this group
-    '''
-
-    logging.log('Begin _min_combo <========================================')
-    logging.log(f'size={len(alumni)}, by="{by}", arg="{arg}", group_size={group_size}')
-
-    if by == 'all' or arg == 'diff':
+  def min_combo_numpy(self, alumni, by=None, arg=None, group_size=6):
+    num_unique_total = None
+    if arg == 'diff':
+      if by == 'all':
+        raise ValueError(f"Incompatible params: by='all', arg='diff'")
+      num_unique_total = len(alumni[by].unique())
       indices = alumni.index
-    else:
+    elif arg != 'diff' and by != 'all':
       indices = alumni[alumni[by] == arg].index
 
-    combos = list(combinations(indices,group_size))
+    this_category = alumni[by].values.astype(str)
+    counts_cols = [col for col in alumni.columns[3:] if '_' not in col]
+    cnsctv_cols = [col for col in alumni.columns[3:] if '_' in col]
+  
+    counts_arr = alumni[counts_cols].values
+    cnsctv_arr = alumni[cnsctv_cols].values
 
-    #!!! Current diff is only for year OR track. Full diff (each group member has different year and different track) not implemented yet
-    if arg == 'diff':
-      diff_start = timer()
-      temp_combos = []
-      for combo in combos:
-        vals = alumni.loc[alumni.index.isin(combo),by]
-        if len(vals) == len(set(vals)):
-          temp_combos.append(combo)
-      if len(temp_combos) == 0:
-        return 1    
-      combos = temp_combos
-      diff_end = timer()
-      logging.log(f'Diff time: {diff_end-diff_start}')
+    # Stack the two arrays side-by-side, giving a shape (N, N*2) where N is
+    # the number of students. 
+    alumni_arr = np.concatenate([counts_arr, cnsctv_arr], axis=1) 
 
-    twoDmask = [[(str(alumn), str(alumn)+'_cnsctv') for alumn in combos[i]] for i in range(len(combos))]
-    masks = [[item for combo in twoDmask[i] for item in combo] for i in range(len(twoDmask))]
+    @jit(nopython=True)
+    def is_combo_diverse(combo):
+      if num_unique_total is None:
+        return True
+      num_unique = len(np.unique(this_category[combo]))
+      if num_unique >= num_unique_total:
+        return True
+      else:
+        return False
 
-    start = timer()
-    sums = [np.sum(alumni.loc[alumni.index.isin(combos[i]),masks[i]].values) for i in range(len(combos))] ### HIGHEST COST STEP
-    end = timer()
+    @jit(nopython=True)
+    def get_sum(arr, combo):
 
-    logging.log(f'Time through highest cost step: {end-start}')
-    logging.log('End _min_combo ========================================>')
+      counts_sum = arr[combo][: , combo]
+      cnsctv_sum = arr[combo][:, combo + len(arr)]
+      return np.sum(counts_sum) + np.sum(cnsctv_sum)
+
+    
+    combos = combinations(indices, group_size)
+    combo_arr = np.array(list(combos), dtype='int8')
+
+    # Apply `is_combo_diverse` to each combo, only returning 'diverse' combos
+    good_combos = np.apply_along_axis(is_combo_diverse, axis=1, arr=combo_arr)
+    combo_arr = combo_arr[np.where(good_combos)]
+
+
+    # Apply `get_sum` to each combo 
+    sums = np.apply_along_axis(lambda combo: get_sum(alumni_arr, combo), axis=1, arr=combo_arr)
 
     min_list = np.where(sums == np.amin(sums))[0]
-  
-    return combos[random.choice(min_list)]
+
+    return combo_arr[random.choice(min_list)]
 
     
 


### PR DESCRIPTION
This PR speeds up the core algorithm by leveraging specific libraries that are designed for fast performance.

The first one of these is `numba`, which is a just-in-time compiler (using a specific version of LLVM). By using the `jit` decorator from `numba`, small well-defined functions can be compiled into C code.:

https://github.com/nneibaue/alumni_shuffler/blob/852feb55b072a9808d3c2c9d9762255817d57d93/zoom_sesh.py#L181-L193

Secondly, the code is now leveraging the `apply_along_axes function from numpy`: 
https://github.com/nneibaue/alumni_shuffler/blob/852feb55b072a9808d3c2c9d9762255817d57d93/zoom_sesh.py#L209

These two changes sped up the code by at least a factor of 10 in some cases. 